### PR TITLE
feat: add use feature toggle

### DIFF
--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,2 +1,3 @@
 export { usePageable } from './usePageable';
 export { useAnalytics } from "./useAnalytics";
+export { useFeatureToggle } from "./useFeatureToggle";

--- a/src/composables/useFeatureToggle/index.ts
+++ b/src/composables/useFeatureToggle/index.ts
@@ -1,0 +1,1 @@
+export { useFeatureToggle } from './useFeatureToggle';

--- a/src/composables/useFeatureToggle/types.ts
+++ b/src/composables/useFeatureToggle/types.ts
@@ -1,0 +1,3 @@
+export interface FeatureRecord extends Record<string, boolean>{};
+
+export interface FeatureRecordList extends Record<string, boolean | FeatureRecord | FeatureRecordList>{};

--- a/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
@@ -5,6 +5,8 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 jest.mock("axios");
 
+const featureTestKey = 'featureTestKey'
+
 describe('useFeatureToggle composable', () => {
   describe('feature toggle object composition', () => {
     it('should test behavior of simple object', async () => {
@@ -17,7 +19,7 @@ describe('useFeatureToggle composable', () => {
       
       const { flatFeaturesRules, loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
   
-      await loadFeatures('wallet');
+      await loadFeatures(featureTestKey);
   
       expect(flatFeaturesRules.value).toStrictEqual(data);
       expect(isFeatureEnabled('testKey')).toBe(data.testKey);
@@ -40,7 +42,7 @@ describe('useFeatureToggle composable', () => {
       
       const { flatFeaturesRules, loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
   
-      await loadFeatures('wallet');
+      await loadFeatures(featureTestKey);
   
       expect(flatFeaturesRules.value).toStrictEqual({
         'testKey1.feature.checkForSomething': true,
@@ -50,6 +52,36 @@ describe('useFeatureToggle composable', () => {
       expect(isFeatureEnabled('testKey2.checkForAnotherThing')).toBe(data.testKey2.checkForAnotherThing);
     });
   })
+
+  describe('isLoading', () => {
+    it('should has loading false at first', async () => {
+      const data = {
+        testKey: true,
+        testKey2: false
+      }
+  
+      mockedAxios.get.mockResolvedValue({ data })
+      
+      const { isLoading } = useFeatureToggle(mockedAxios);
+
+      expect(isLoading.value).toBe(false);
+    })
+
+    it('should has loading false after request', async () => {
+      const data = {
+        testKey: true,
+        testKey2: false
+      }
+  
+      mockedAxios.get.mockResolvedValue({ data })
+      
+      const { loadFeatures, isLoading } = useFeatureToggle(mockedAxios);
+
+      await loadFeatures(featureTestKey);
+
+      expect(isLoading.value).toBe(false);
+    })
+  });
 
   describe('validations', () => {
     it('should return true for no provided key', async () => {
@@ -68,7 +100,7 @@ describe('useFeatureToggle composable', () => {
       
       const { loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
   
-      await loadFeatures('wallet');
+      await loadFeatures(featureTestKey);
 
       expect(isFeatureEnabled('')).toBeTruthy();
     });
@@ -89,7 +121,7 @@ describe('useFeatureToggle composable', () => {
       
       const { loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
   
-      await loadFeatures('wallet');
+      await loadFeatures(featureTestKey);
 
       expect(isFeatureEnabled('testKey3.feature.check')).toBeFalsy();
     });

--- a/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
@@ -19,7 +19,7 @@ describe('useFeatureToggle composable', () => {
   
       await loadFeatures('wallet');
   
-      expect(flatFeaturesRules.value).toEqual(data)
+      expect(flatFeaturesRules.value).toStrictEqual(data);
       expect(isFeatureEnabled('testKey')).toBe(data.testKey);
       expect(isFeatureEnabled('testKey2')).toBe(data.testKey2);
     });
@@ -38,19 +38,21 @@ describe('useFeatureToggle composable', () => {
   
       mockedAxios.get.mockResolvedValue({ data })
       
-      const { flatFeaturesRules, loadFeatures } = useFeatureToggle(mockedAxios);
+      const { flatFeaturesRules, loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
   
       await loadFeatures('wallet');
   
-      expect(flatFeaturesRules.value).toEqual({
+      expect(flatFeaturesRules.value).toStrictEqual({
         'testKey1.feature.checkForSomething': true,
         'testKey2.checkForAnotherThing': true
       })
+      expect(isFeatureEnabled('testKey1.feature.checkForSomething')).toBe(data.testKey1.feature.checkForSomething);
+      expect(isFeatureEnabled('testKey2.checkForAnotherThing')).toBe(data.testKey2.checkForAnotherThing);
     });
   })
 
-  describe('isFeatureEnabled', () => {
-    it('should return true for an absent key', async () => {
+  describe('validations', () => {
+    it('should return true for no provided key', async () => {
       const data = {
         "testKey1": {
           "feature": {

--- a/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
@@ -1,5 +1,3 @@
-// mock client.get (axios instance)
-
 import axios from "axios";
 import { useFeatureToggle } from "./useFeatureToggle";
 
@@ -17,11 +15,13 @@ describe('useFeatureToggle composable', () => {
   
       mockedAxios.get.mockResolvedValue({ data })
       
-      const { flatFeaturesRules, loadFeatures } = useFeatureToggle(mockedAxios);
+      const { flatFeaturesRules, loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
   
       await loadFeatures('wallet');
   
       expect(flatFeaturesRules.value).toEqual(data)
+      expect(isFeatureEnabled('testKey')).toBe(data.testKey);
+      expect(isFeatureEnabled('testKey2')).toBe(data.testKey2);
     });
   
     it('should test behavior of deep object', async () => {

--- a/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
@@ -9,8 +9,8 @@ describe('useFeatureToggle composable', () => {
   describe('feature toggle object composition', () => {
     it('should test behavior of simple object', async () => {
       const data = {
-        'testKey': true,
-        'testKey2': false
+        testKey: true,
+        testKey2: false
       }
   
       mockedAxios.get.mockResolvedValue({ data })
@@ -26,13 +26,13 @@ describe('useFeatureToggle composable', () => {
   
     it('should test behavior of deep object', async () => {
       const data = {
-        "testKey1": {
-          "feature": {
-            "checkForSomething": true
+        testKey1: {
+          feature: {
+            checkForSomething: true
           }
         },
-        "testKey2": {
-          "checkForAnotherThing": true
+        testKey2: {
+          checkForAnotherThing: true
         }
       }
   
@@ -54,13 +54,13 @@ describe('useFeatureToggle composable', () => {
   describe('validations', () => {
     it('should return true for no provided key', async () => {
       const data = {
-        "testKey1": {
-          "feature": {
-            "checkForSomething": true
+        testKey1: {
+          feature: {
+            checkForSomething: true
           }
         },
-        "testKey2": {
-          "checkForAnotherThing": true
+        testKey2: {
+          checkForAnotherThing: true
         }
       }
   
@@ -75,13 +75,13 @@ describe('useFeatureToggle composable', () => {
 
     it('should return false for an invalid key', async () => {
       const data = {
-        "testKey1": {
-          "feature": {
-            "checkForSomething": true
+        testKey1: {
+          feature: {
+            checkForSomething: true
           }
         },
-        "testKey2": {
-          "checkForAnotherThing": true
+        testKey2: {
+          checkForAnotherThing: true
         }
       }
   

--- a/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import axios from 'axios';
 import { useFeatureToggle } from './useFeatureToggle';
 

--- a/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
@@ -1,137 +1,150 @@
-import axios from "axios";
-import { useFeatureToggle } from "./useFeatureToggle";
+import axios from 'axios';
+import { useFeatureToggle } from './useFeatureToggle';
 
-jest.mock("axios");
+jest.mock('axios');
 
-const featureTestKey = 'featureTestKey'
+const featureTestKey = 'featureTestKey';
 
 // Important: this composable share state, that's why we need to clean `flatFeaturesRules.value`
 describe('useFeatureToggle composable', () => {
-  let mockedAxios = axios as jest.Mocked<typeof axios>;
+	let mockedAxios = axios as jest.Mocked<typeof axios>;
 
-  describe('feature toggle object composition', () => {
-    it('should test behavior of simple object', async () => {
-      const data = {
-        testKey: true,
-        testKey2: false
-      }
-  
-      mockedAxios.get.mockResolvedValue({ data })
-      
-      const { flatFeaturesRules, loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
-  
-      await loadFeatures(featureTestKey);
-  
-      expect(flatFeaturesRules.value).toStrictEqual(data);
-      expect(isFeatureEnabled('testKey')).toBe(data.testKey);
-      expect(isFeatureEnabled('testKey2')).toBe(data.testKey2);
-    });
-  
-    it('should test behavior of deep object', async () => {
-      const data = {
-        testKey1: {
-          feature: {
-            checkForSomething: true
-          }
-        },
-        testKey2: {
-          checkForAnotherThing: true
-        }
-      }
-  
-      mockedAxios.get.mockResolvedValue({ data })
-      
-      const { flatFeaturesRules, loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
-  
-      await loadFeatures(featureTestKey);
-  
-      expect(flatFeaturesRules.value).toStrictEqual({
-        'testKey1.feature.checkForSomething': true,
-        'testKey2.checkForAnotherThing': true
-      })
-      expect(isFeatureEnabled('testKey1.feature.checkForSomething')).toBe(data.testKey1.feature.checkForSomething);
-      expect(isFeatureEnabled('testKey2.checkForAnotherThing')).toBe(data.testKey2.checkForAnotherThing);
-    });
-  })
+	describe('feature toggle object composition', () => {
+		it('should test behavior of simple object', async () => {
+			const data = {
+				testKey: true,
+				testKey2: false,
+			};
 
-  describe('isLoading', () => {
-    it('should have loading false at first and after request', async () => {
-      const data = {
-        testKey: true,
-        testKey2: false
-      }
-  
-      mockedAxios.get.mockResolvedValue({ data })
-      
-      const { isLoading, loadFeatures } = useFeatureToggle(mockedAxios);
+			mockedAxios.get.mockResolvedValue({ data });
 
-      expect(isLoading.value).toBe(false);
+			const { flatFeaturesRules, loadFeatures, isFeatureEnabled } =
+				useFeatureToggle();
 
-      await loadFeatures(featureTestKey);
+			await loadFeatures(mockedAxios, featureTestKey);
 
-      expect(isLoading.value).toBe(false);
-    });
+			expect(flatFeaturesRules.value).toStrictEqual(data);
+			expect(isFeatureEnabled('testKey')).toBe(data.testKey);
+			expect(isFeatureEnabled('testKey2')).toBe(data.testKey2);
+		});
 
-    it('should have loading false after failed request and not have any rules', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn);
-  
-      mockedAxios.get.mockRejectedValue(new Error('No data'))
-      
-      const { flatFeaturesRules, isLoading, loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
+		it('should test behavior of deep object', async () => {
+			const data = {
+				testKey1: {
+					feature: {
+						checkForSomething: true,
+					},
+				},
+				testKey2: {
+					checkForAnotherThing: true,
+				},
+			};
 
-      // Reset shared feature flags to test if they will be empty
-      flatFeaturesRules.value = {};
+			mockedAxios.get.mockResolvedValue({ data });
 
-      await loadFeatures(featureTestKey);
+			const { flatFeaturesRules, loadFeatures, isFeatureEnabled } =
+				useFeatureToggle();
 
-      expect(isLoading.value).toBe(false);
-      expect(consoleSpy).toHaveBeenCalledTimes(1);
-      expect(isFeatureEnabled('testKey')).toBeFalsy();
-      expect(flatFeaturesRules.value).toStrictEqual({});
-    });
-  });
+			await loadFeatures(mockedAxios, featureTestKey);
 
-  describe('validations', () => {
-    it('should return true for no provided key', async () => {
-      const data = {
-        testKey1: {
-          feature: {
-            checkForSomething: true
-          }
-        },
-        testKey2: {
-          checkForAnotherThing: true
-        }
-      }
-  
-      mockedAxios.get.mockResolvedValue({ data })
-      
-      const { loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
-  
-      await loadFeatures(featureTestKey);
+			expect(flatFeaturesRules.value).toStrictEqual({
+				'testKey1.feature.checkForSomething': true,
+				'testKey2.checkForAnotherThing': true,
+			});
+			expect(isFeatureEnabled('testKey1.feature.checkForSomething')).toBe(
+				data.testKey1.feature.checkForSomething,
+			);
+			expect(isFeatureEnabled('testKey2.checkForAnotherThing')).toBe(
+				data.testKey2.checkForAnotherThing,
+			);
+		});
+	});
 
-      expect(isFeatureEnabled('')).toBeTruthy();
-    });
+	describe('isLoading', () => {
+		it('should have loading false at first and after request', async () => {
+			const data = {
+				testKey: true,
+				testKey2: false,
+			};
 
-    it('should return false for an invalid key', async () => {
-      const data = {
-        testKey1: {
-          feature: {
-            checkForSomething: true
-          }
-        },
-        testKey2: {
-          checkForAnotherThing: true
-        }
-      }
-  
-      mockedAxios.get.mockResolvedValue({ data })
-      
-      const { loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
-  
-      await loadFeatures(featureTestKey);
+			mockedAxios.get.mockResolvedValue({ data });
 
-      expect(isFeatureEnabled('testKey3.feature.check')).toBeFalsy();
-    });
-  })
-})
+			const { isLoading, loadFeatures } = useFeatureToggle();
+
+			expect(isLoading.value).toBe(false);
+
+			await loadFeatures(mockedAxios, featureTestKey);
+
+			expect(isLoading.value).toBe(false);
+		});
+
+		it('should have loading false after failed request and not have any rules', async () => {
+			const consoleSpy = jest
+				.spyOn(console, 'error')
+				.mockImplementation(jest.fn);
+
+			mockedAxios.get.mockRejectedValue(new Error('No data'));
+
+			const {
+				flatFeaturesRules,
+				isLoading,
+				loadFeatures,
+				isFeatureEnabled,
+			} = useFeatureToggle();
+
+			// Reset shared feature flags to test if they will be empty
+			flatFeaturesRules.value = {};
+
+			await loadFeatures(mockedAxios, featureTestKey);
+
+			expect(isLoading.value).toBe(false);
+			expect(consoleSpy).toHaveBeenCalledTimes(1);
+			expect(isFeatureEnabled('testKey')).toBeFalsy();
+			expect(flatFeaturesRules.value).toStrictEqual({});
+		});
+	});
+
+	describe('validations', () => {
+		it('should return true for no provided key', async () => {
+			const data = {
+				testKey1: {
+					feature: {
+						checkForSomething: true,
+					},
+				},
+				testKey2: {
+					checkForAnotherThing: true,
+				},
+			};
+
+			mockedAxios.get.mockResolvedValue({ data });
+
+			const { loadFeatures, isFeatureEnabled } = useFeatureToggle();
+
+			await loadFeatures(mockedAxios, featureTestKey);
+
+			expect(isFeatureEnabled('')).toBeTruthy();
+		});
+
+		it('should return false for an invalid key', async () => {
+			const data = {
+				testKey1: {
+					feature: {
+						checkForSomething: true,
+					},
+				},
+				testKey2: {
+					checkForAnotherThing: true,
+				},
+			};
+
+			mockedAxios.get.mockResolvedValue({ data });
+
+			const { loadFeatures, isFeatureEnabled } = useFeatureToggle();
+
+			await loadFeatures(mockedAxios, featureTestKey);
+
+			expect(isFeatureEnabled('testKey3.feature.check')).toBeFalsy();
+		});
+	});
+});

--- a/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
@@ -1,0 +1,95 @@
+// mock client.get (axios instance)
+
+import axios from "axios";
+import { useFeatureToggle } from "./useFeatureToggle";
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+jest.mock("axios");
+
+describe('useFeatureToggle composable', () => {
+  describe('feature toggle object composition', () => {
+    it('should test behavior of simple object', async () => {
+      const data = {
+        'testKey': true,
+        'testKey2': false
+      }
+  
+      mockedAxios.get.mockResolvedValue({ data })
+      
+      const { flatFeaturesRules, loadFeatures } = useFeatureToggle(mockedAxios);
+  
+      await loadFeatures('wallet');
+  
+      expect(flatFeaturesRules.value).toEqual(data)
+    });
+  
+    it('should test behavior of deep object', async () => {
+      const data = {
+        "testKey1": {
+          "feature": {
+            "checkForSomething": true
+          }
+        },
+        "testKey2": {
+          "checkForAnotherThing": true
+        }
+      }
+  
+      mockedAxios.get.mockResolvedValue({ data })
+      
+      const { flatFeaturesRules, loadFeatures } = useFeatureToggle(mockedAxios);
+  
+      await loadFeatures('wallet');
+  
+      expect(flatFeaturesRules.value).toEqual({
+        'testKey1.feature.checkForSomething': true,
+        'testKey2.checkForAnotherThing': true
+      })
+    });
+  })
+
+  describe('isFeatureEnabled', () => {
+    it('should return true for an absent key', async () => {
+      const data = {
+        "testKey1": {
+          "feature": {
+            "checkForSomething": true
+          }
+        },
+        "testKey2": {
+          "checkForAnotherThing": true
+        }
+      }
+  
+      mockedAxios.get.mockResolvedValue({ data })
+      
+      const { loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
+  
+      await loadFeatures('wallet');
+
+      expect(isFeatureEnabled('')).toBeTruthy();
+    });
+
+    it('should return false for an invalid key', async () => {
+      const data = {
+        "testKey1": {
+          "feature": {
+            "checkForSomething": true
+          }
+        },
+        "testKey2": {
+          "checkForAnotherThing": true
+        }
+      }
+  
+      mockedAxios.get.mockResolvedValue({ data })
+      
+      const { loadFeatures, isFeatureEnabled } = useFeatureToggle(mockedAxios);
+  
+      await loadFeatures('wallet');
+
+      expect(isFeatureEnabled('testKey3.feature.check')).toBeFalsy();
+    });
+  })
+})

--- a/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.spec.ts
@@ -5,6 +5,7 @@ jest.mock("axios");
 
 const featureTestKey = 'featureTestKey'
 
+// Important: this composable share state, that's why we need to clean `flatFeaturesRules.value`
 describe('useFeatureToggle composable', () => {
   let mockedAxios = axios as jest.Mocked<typeof axios>;
 

--- a/src/composables/useFeatureToggle/useFeatureToggle.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.ts
@@ -1,10 +1,10 @@
 import { ref } from "vue";
-import { flatObject } from "../../helpers/flatObject";
+import flatObject from "../../helpers/flatObject";
 
 import type { AxiosInstance } from "axios";
-import type { FlattenedRecordList } from "../../helpers/flatObject/types";
+import type { RecordListToFlatten } from "../../helpers/flatObject/types";
 
-let flatFeaturesRules = ref<FlattenedRecordList<boolean>>({});
+let flatFeaturesRules = ref<RecordListToFlatten<boolean>>({});
 
 export function useFeatureToggle (client: AxiosInstance) {
   /**
@@ -14,9 +14,9 @@ export function useFeatureToggle (client: AxiosInstance) {
    * @param name - The name of the file from where you want to get features
    */
   async function loadFeatures (name: string) {
-    const { data } = await client.get<FlattenedRecordList<boolean>>(`/features/${name}.json`);
+    const { data } = await client.get<RecordListToFlatten<boolean>>(`/features/${name}.json`);
     
-    flatFeaturesRules.value = flatObject(data) as FlattenedRecordList<boolean>;
+    flatFeaturesRules.value = flatObject(data) as RecordListToFlatten<boolean>;
   }
 
   /**

--- a/src/composables/useFeatureToggle/useFeatureToggle.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.ts
@@ -1,0 +1,38 @@
+import type { AxiosInstance } from "axios";
+import type { FeatureRecordList } from "./types";
+import { flatObject } from "../../helpers/flatObject";
+import { ref } from "vue";
+
+let flatFeaturesRules = ref<ReturnType<typeof flatObject<boolean>>>({});
+
+export function useFeatureToggle (client: AxiosInstance) {
+  /**
+   * Fetch for feature flags in /features folder, which will be there after build of `front-mfe-orquestrador`
+   * or if we build `front-mfe-toogle-features`
+   * 
+   * @param name - The name of the file from where you want to get features
+   */
+  async function loadFeatures (name: string) {
+    const { data } = await client.get<FeatureRecordList>(`/features/${name}.json`);
+    
+    flatFeaturesRules.value = flatObject(data);
+  }
+
+  /**
+   * Check if a feature key is present and active
+   * 
+   * @param key - Name of the key in a "flat-object" format, e.g: `wallet.notes.hasList`
+   */
+  function isFeatureEnabled (key: keyof typeof flatFeaturesRules.value) {
+    if (!key) {
+      return true;
+    }
+    return flatFeaturesRules.value[key] || false;
+  }
+
+  return {
+    flatFeaturesRules,
+    loadFeatures,
+    isFeatureEnabled
+  }
+}

--- a/src/composables/useFeatureToggle/useFeatureToggle.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.ts
@@ -14,9 +14,9 @@ export function useFeatureToggle (client: AxiosInstance) {
    * @param name - The name of the file from where you want to get features
    */
   async function loadFeatures (name: string) {
-    const { data } = await client.get<RecordListToFlatten<boolean>>(`/features/${name}.json`);
+    const { data } = await client.get<typeof flatFeaturesRules.value>(`/features/${name}.json`);
     
-    flatFeaturesRules.value = flatObject(data) as RecordListToFlatten<boolean>;
+    flatFeaturesRules.value = flatObject(data);
   }
 
   /**

--- a/src/composables/useFeatureToggle/useFeatureToggle.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.ts
@@ -16,6 +16,7 @@ export function useFeatureToggle (client: AxiosInstance) {
    */
   async function loadFeatures (name: string) {
     isLoading.value = true
+
     try {
       const { data } = await client.get<typeof flatFeaturesRules.value>(`/features/${name}.json`);
 

--- a/src/composables/useFeatureToggle/useFeatureToggle.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.ts
@@ -7,6 +7,7 @@ import type { RecordListToFlatten } from "../../helpers/flatObject/types";
 let flatFeaturesRules = ref<RecordListToFlatten<boolean>>({});
 
 export function useFeatureToggle (client: AxiosInstance) {
+  const isLoading = ref(false);
   /**
    * Fetch for feature flags in /features folder, which will be there after build of `front-mfe-orquestrador`
    * or if we build `front-mfe-toogle-features`
@@ -14,9 +15,16 @@ export function useFeatureToggle (client: AxiosInstance) {
    * @param name - The name of the file from where you want to get features
    */
   async function loadFeatures (name: string) {
-    const { data } = await client.get<typeof flatFeaturesRules.value>(`/features/${name}.json`);
-    
-    flatFeaturesRules.value = flatObject(data);
+    isLoading.value = true
+    try {
+      const { data } = await client.get<typeof flatFeaturesRules.value>(`/features/${name}.json`);
+
+      flatFeaturesRules.value = flatObject(data);
+    } catch (e) {
+      console.error(`Not able to load feature flags, Error: ${e}`);
+    } finally {
+      isLoading.value = false
+    }
   }
 
   /**
@@ -32,6 +40,7 @@ export function useFeatureToggle (client: AxiosInstance) {
   }
 
   return {
+    isLoading,
     flatFeaturesRules,
     loadFeatures,
     isFeatureEnabled

--- a/src/composables/useFeatureToggle/useFeatureToggle.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.ts
@@ -1,9 +1,10 @@
-import type { AxiosInstance } from "axios";
-import type { FeatureRecordList } from "./types";
-import { flatObject } from "../../helpers/flatObject";
 import { ref } from "vue";
+import { flatObject } from "../../helpers/flatObject";
 
-let flatFeaturesRules = ref<ReturnType<typeof flatObject<boolean>>>({});
+import type { AxiosInstance } from "axios";
+import type { FlattenedRecordList } from "../../helpers/flatObject/types";
+
+let flatFeaturesRules = ref<FlattenedRecordList<boolean>>({});
 
 export function useFeatureToggle (client: AxiosInstance) {
   /**
@@ -13,9 +14,9 @@ export function useFeatureToggle (client: AxiosInstance) {
    * @param name - The name of the file from where you want to get features
    */
   async function loadFeatures (name: string) {
-    const { data } = await client.get<FeatureRecordList>(`/features/${name}.json`);
+    const { data } = await client.get<FlattenedRecordList<boolean>>(`/features/${name}.json`);
     
-    flatFeaturesRules.value = flatObject(data);
+    flatFeaturesRules.value = flatObject(data) as FlattenedRecordList<boolean>;
   }
 
   /**

--- a/src/composables/useFeatureToggle/useFeatureToggle.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.ts
@@ -1,10 +1,11 @@
 import { ref } from 'vue';
-import flatObject from '../../helpers/flatObject';
+
+import { flatObject } from '../../helpers';
 
 import type { AxiosInstance } from 'axios';
-import type { RecordListToFlatten } from '../../helpers/flatObject/types';
+import type { FlattenedRecordList } from '../../helpers/flatObject/types';
 
-let flatFeaturesRules = ref<RecordListToFlatten<boolean>>({});
+let flatFeaturesRules = ref<FlattenedRecordList<boolean>>({});
 
 export function useFeatureToggle() {
 	const isLoading = ref(false);

--- a/src/composables/useFeatureToggle/useFeatureToggle.ts
+++ b/src/composables/useFeatureToggle/useFeatureToggle.ts
@@ -1,49 +1,51 @@
-import { ref } from "vue";
-import flatObject from "../../helpers/flatObject";
+import { ref } from 'vue';
+import flatObject from '../../helpers/flatObject';
 
-import type { AxiosInstance } from "axios";
-import type { RecordListToFlatten } from "../../helpers/flatObject/types";
+import type { AxiosInstance } from 'axios';
+import type { RecordListToFlatten } from '../../helpers/flatObject/types';
 
 let flatFeaturesRules = ref<RecordListToFlatten<boolean>>({});
 
-export function useFeatureToggle (client: AxiosInstance) {
-  const isLoading = ref(false);
-  /**
-   * Fetch for feature flags in /features folder, which will be there after build of `front-mfe-orquestrador`
-   * or if we build `front-mfe-toogle-features`
-   * 
-   * @param name - The name of the file from where you want to get features
-   */
-  async function loadFeatures (name: string) {
-    isLoading.value = true
+export function useFeatureToggle() {
+	const isLoading = ref(false);
+	/**
+	 * Fetch for feature flags in /features folder, which will be there after build of `front-mfe-orquestrador`
+	 * or if we build `front-mfe-toogle-features`
+	 *
+	 * @param name - The name of the file from where you want to get features
+	 */
+	async function loadFeatures(client: AxiosInstance, name: string) {
+		isLoading.value = true;
 
-    try {
-      const { data } = await client.get<typeof flatFeaturesRules.value>(`/features/${name}.json`);
+		try {
+			const { data } = await client.get<typeof flatFeaturesRules.value>(
+				`/features/${name}.json`,
+			);
 
-      flatFeaturesRules.value = flatObject(data);
-    } catch (e) {
-      console.error(`Not able to load feature flags, Error: ${e}`);
-    } finally {
-      isLoading.value = false
-    }
-  }
+			flatFeaturesRules.value = flatObject(data);
+		} catch (e) {
+			console.error(`Not able to load feature flags, Error: ${e}`);
+		} finally {
+			isLoading.value = false;
+		}
+	}
 
-  /**
-   * Check if a feature key is present and active
-   * 
-   * @param key - Name of the key in a "flat-object" format, e.g: `wallet.notes.hasList`
-   */
-  function isFeatureEnabled (key: keyof typeof flatFeaturesRules.value) {
-    if (!key) {
-      return true;
-    }
-    return flatFeaturesRules.value[key] || false;
-  }
+	/**
+	 * Check if a feature key is present and active
+	 *
+	 * @param key - Name of the key in a "flat-object" format, e.g: `wallet.notes.hasList`
+	 */
+	function isFeatureEnabled(key: keyof typeof flatFeaturesRules.value) {
+		if (!key) {
+			return true;
+		}
+		return flatFeaturesRules.value[key] || false;
+	}
 
-  return {
-    isLoading,
-    flatFeaturesRules,
-    loadFeatures,
-    isFeatureEnabled
-  }
+	return {
+		isLoading,
+		flatFeaturesRules,
+		loadFeatures,
+		isFeatureEnabled,
+	};
 }

--- a/src/helpers/flatObject/flatObject.spec.ts
+++ b/src/helpers/flatObject/flatObject.spec.ts
@@ -20,7 +20,7 @@ describe('flatObject', () => {
       }
     };
 
-    expect(flatObject(data)).toStrictEqual({
+    expect(flatObject<string | boolean>(data)).toStrictEqual({
       'testKey.testKeyDeep': true,
       'testKey2.testKey2Deep': 'test'
     });

--- a/src/helpers/flatObject/flatObject.spec.ts
+++ b/src/helpers/flatObject/flatObject.spec.ts
@@ -1,0 +1,28 @@
+import { flatObject } from "./flatObject";
+
+describe('flatObject', () => {
+  it('should keep shallow object as it is', () => {
+    const data = {
+      testKey: 10,
+      testKey2: 5
+    };
+
+    expect(flatObject(data)).toStrictEqual(data);
+  });
+
+  it('should flatten a deep object', () => {
+    const data = {
+      testKey: {
+        testKeyDeep: true
+      },
+      testKey2: {
+        testKey2Deep: 'test'
+      }
+    };
+
+    expect(flatObject(data)).toStrictEqual({
+      'testKey.testKeyDeep': true,
+      'testKey2.testKey2Deep': 'test'
+    });
+  });
+});

--- a/src/helpers/flatObject/flatObject.ts
+++ b/src/helpers/flatObject/flatObject.ts
@@ -1,4 +1,4 @@
-import type { FlattenedRecord, FlattenedRecordList } from "./types";
+import type { FlattenedRecordList, RecordListToFlatten, RecordToFlatten } from "./types";
 
 /**
  * Flatten an object joining nested keys into string.
@@ -25,19 +25,21 @@ import type { FlattenedRecord, FlattenedRecordList } from "./types";
  * }
  * ```
  */
-export function flatObject<T = unknown>(obj: FlattenedRecord<T>): FlattenedRecordList<T> {
+export function flatObject<T = unknown>(obj: RecordListToFlatten<T>): FlattenedRecordList<T> {
 	let flatObj: FlattenedRecordList<T> = {};
 	let path: string[] = [];
 
-	function recursiveFlattening(recordToFlatten: T | FlattenedRecordList<T>) {
-		if (recordToFlatten !== Object(recordToFlatten)) {
+	function recursiveFlattening(recordToFlatten: RecordToFlatten<T>) {
+		const isARecordListToFlatten = (value: RecordToFlatten<T>): value is RecordListToFlatten<T> => value === Object(value)
+
+		if (!isARecordListToFlatten(recordToFlatten)) {
 			return (flatObj[path.join('.')] = recordToFlatten);
 		}
 
-		for (const key in recordToFlatten as FlattenedRecordList<T>) {
-			if (key in (recordToFlatten as FlattenedRecordList<T>)) {
+		for (const key in recordToFlatten) {
+			if (key in recordToFlatten) {
 				path.push(key);
-				recursiveFlattening((recordToFlatten as FlattenedRecordList<T>)[key]);
+				recursiveFlattening(recordToFlatten[key]);
 				path.pop();
 			}
 		}

--- a/src/helpers/flatObject/flatObject.ts
+++ b/src/helpers/flatObject/flatObject.ts
@@ -1,0 +1,21 @@
+export function flatObject<T = any>(obj: any): Record<string, T> {
+	let flatObj: any = {};
+	let path: Array<any> = [];
+
+	function dig(objDig: any) {
+		if (objDig !== Object(objDig)) {
+			return (flatObj[path.join('.')] = objDig);
+		}
+
+		for (const key in objDig) {
+			if (Object.prototype.hasOwnProperty.call(objDig, key)) {
+				path.push(key);
+				dig(objDig[key]);
+				path.pop();
+			}
+		}
+	}
+
+	dig(obj);
+	return flatObj;
+}

--- a/src/helpers/flatObject/flatObject.ts
+++ b/src/helpers/flatObject/flatObject.ts
@@ -1,21 +1,48 @@
-export function flatObject<T = any>(obj: any): Record<string, T> {
-	let flatObj: any = {};
-	let path: Array<any> = [];
+import type { FlattenedRecord, FlattenedRecordList } from "./types";
 
-	function dig(objDig: any) {
-		if (objDig !== Object(objDig)) {
-			return (flatObj[path.join('.')] = objDig);
+/**
+ * Flatten an object joining nested keys into string.
+ * 
+ * @example
+ * ```js
+ * const input = {
+ * 	key: {
+ * 		nestedKey: true
+ * 	},
+ * 	secondKey: {
+ * 		nestedKey: {
+ * 			deepNestedKey: 123
+ * 		}
+ * 	}
+ * }
+ * 
+ * const output = flatObject(input)
+ * 
+ * // output:
+ * {
+ * 	'key.nestedKey': true
+ * 	'secondKey.nestedKey.deepNestedKey': 123
+ * }
+ * ```
+ */
+export function flatObject<T = unknown>(obj: FlattenedRecord<T>): FlattenedRecordList<T> {
+	let flatObj: FlattenedRecordList<T> = {};
+	let path: string[] = [];
+
+	function recursiveFlattening(recordToFlatten: T | FlattenedRecordList<T>) {
+		if (recordToFlatten !== Object(recordToFlatten)) {
+			return (flatObj[path.join('.')] = recordToFlatten);
 		}
 
-		for (const key in objDig) {
-			if (Object.prototype.hasOwnProperty.call(objDig, key)) {
+		for (const key in recordToFlatten as FlattenedRecordList<T>) {
+			if (key in (recordToFlatten as FlattenedRecordList<T>)) {
 				path.push(key);
-				dig(objDig[key]);
+				recursiveFlattening((recordToFlatten as FlattenedRecordList<T>)[key]);
 				path.pop();
 			}
 		}
 	}
 
-	dig(obj);
+	recursiveFlattening(obj);
 	return flatObj;
 }

--- a/src/helpers/flatObject/index.ts
+++ b/src/helpers/flatObject/index.ts
@@ -1,0 +1,1 @@
+export { flatObject } from './flatObject';

--- a/src/helpers/flatObject/index.ts
+++ b/src/helpers/flatObject/index.ts
@@ -1,1 +1,3 @@
-export { flatObject } from './flatObject';
+import { flatObject } from './flatObject';
+
+export default flatObject;

--- a/src/helpers/flatObject/types.ts
+++ b/src/helpers/flatObject/types.ts
@@ -1,3 +1,5 @@
-export interface FlattenedRecord<T> extends Record<string, T>{};
+export interface FlattenedRecordList<T> extends Record<string, T>{};
 
-export interface FlattenedRecordList<T> extends Record<string, T | FlattenedRecord<T> | FlattenedRecordList<T>>{};
+export interface RecordListToFlatten<T> extends Record<string, T | FlattenedRecordList<T> | RecordListToFlatten<T>>{};
+
+export type RecordToFlatten<T> = T | RecordListToFlatten<T>;

--- a/src/helpers/flatObject/types.ts
+++ b/src/helpers/flatObject/types.ts
@@ -1,0 +1,3 @@
+export interface FlattenedRecord<T> extends Record<string, T>{};
+
+export interface FlattenedRecordList<T> extends Record<string, T | FlattenedRecord<T> | FlattenedRecordList<T>>{};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -15,10 +15,12 @@ import toClipboard from './toClipboard';
 import localStorageWrapper from './localStorageWrapper';
 import cacheClient from './cacheClient';
 import axiosWrapper from './axiosWrapper';
+import flatObject from './flatObject';
 import * as types from './types';
 
 export {
 	file,
+	flatObject,
 	queryString,
 	fileSaver,
 	errorBuilder,


### PR DESCRIPTION
Add new feature toggle composable (to replace current mixin)
Make `flatObject` as an aside helper

Migration:

### In your MFE:

#### File: `main.ts`

- Remove `import '@/mixins/featureToggle';`

#### File: `App.vue`

- Import `useFeatureToggle` from this package and extract `loadFeatures` function:

![image](https://github.com/Farm-Investimentos/front-mfe-libs-ts/assets/18626963/d2e36869-f163-41ea-b631-895b84d38a8d)

- In onBeforeMount hook, replace the `internalInstance.loadFeatures` function to `loadFeatures` imported from this package using default axios:

![image](https://github.com/Farm-Investimentos/front-mfe-libs-ts/assets/18626963/e5c2f5f6-3757-46aa-9a89-9057768868cb)

### File: any component

- You also need to import `useFeatureToggle` and extract `isFeatureEnabled` in any component that needs a checking