### PR TITLE
feat: add error builder options

### DIFF
--- a/src/helpers/errorBuilder/errorBuilder.spec.ts
+++ b/src/helpers/errorBuilder/errorBuilder.spec.ts
@@ -78,6 +78,74 @@ describe('ErrorBuilder', () => {
 		expect(r.message).toEqual('some error');
 	});
 
+	it('Should return default message for empty array value', () => {
+		const errors = ['some error', '', 'dasdas'];
+
+		const r = errorBuilder({
+			response: {
+				status: 401,
+				data: {
+					errors,
+				},
+			},
+		});
+		expect(r.message).toEqual('some error. Erro inesperado. dasdas');
+	});
+
+	it('Should return error for multiple array length', () => {
+		const errors = ['some error', 'dasdas'];
+
+		const r = errorBuilder({
+			response: {
+				status: 401,
+				data: {
+					errors,
+				},
+			},
+		});
+		expect(r.message).toEqual(errors.join('. '));
+	});
+
+	it('Should return error for multiple array length with object', () => {
+		const errors = [
+			{ defaultMessage: 'some error' },
+			{ defaultMessage: 'dasdas' },
+		];
+
+		const r = errorBuilder({
+			response: {
+				status: 401,
+				data: {
+					errors,
+				},
+			},
+		});
+		expect(r.message).toEqual(
+			errors.map((v) => v.defaultMessage).join('. '),
+		);
+	});
+
+	it('Should separate by a different character when options are used', () => {
+		const options = {
+			separator: ', ',
+		};
+
+		const errors = ['some error', 'dasdas'];
+
+		const r = errorBuilder(
+			{
+				response: {
+					status: 401,
+					data: {
+						errors,
+					},
+				},
+			},
+			options,
+		);
+		expect(r.message).toEqual(errors.join(options.separator));
+	});
+
 	it('Should remove html markup', () => {
 		const r = errorBuilder({
 			response: {

--- a/src/helpers/errorBuilder/errorBuilder.ts
+++ b/src/helpers/errorBuilder/errorBuilder.ts
@@ -7,9 +7,14 @@
  */
 
 import { IRequestStatus } from 'interfaces';
-import { ErrorType } from './type';
+import type { ErrorBuilderOptions, ErrorType } from './type';
 
-export default (error: Record<string, any>) => {
+const errorBuilderOptions = { separator: '. ' };
+
+export default (
+	error: Record<string, any>,
+	options: ErrorBuilderOptions = errorBuilderOptions,
+) => {
 	const err: Record<string, any> | IRequestStatus = {
 		type: 'ERROR',
 	};
@@ -42,7 +47,7 @@ export default (error: Record<string, any>) => {
 						if (item.defaultMessage) return item.defaultMessage;
 						return item;
 					})
-					.join('. ');
+					.join(options.separator);
 			}
 		}
 	}
@@ -52,7 +57,7 @@ export default (error: Record<string, any>) => {
 	}
 
 	if (Array.isArray(err.message)) {
-		err.message = err.message.join('. ');
+		err.message = err.message.join(options.separator);
 	}
 
 	if (err.message) {

--- a/src/helpers/errorBuilder/type.ts
+++ b/src/helpers/errorBuilder/type.ts
@@ -4,3 +4,7 @@ export type ErrorType = {
 	message: string;
 	httpStatus: string;
 };
+
+export type ErrorBuilderOptions = {
+	separator?: string;
+};


### PR DESCRIPTION
Add options object to pass additional parameters.

For now we have `separator` that is a way to `join` each error in an array with a different character.

There is no effect on what is running right now and is useful for parsing some errors, like when you have validation errors from an import:

From this:
![image](https://github.com/Farm-Investimentos/front-mfe-libs-ts/assets/18626963/4017b425-18aa-4b53-bb39-97bbccca9fa5)

You could do this:

![image](https://github.com/Farm-Investimentos/front-mfe-libs-ts/assets/18626963/6d2601e1-ff2b-4387-a815-cc34eb122f1f)
