### PR TITLE
Feat: adiciona store Pinia userAccess para MFEs Vue 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@farm-investimentos/front-mfe-libs-ts",
-	"version": "3.3.3",
+	"version": "3.4.0",
 	"author": "farm investimentos",
 	"description": "",
 	"license": "ISC",
@@ -26,11 +26,24 @@
 		"husky": "^8.0.1",
 		"jest": "^28.1.0",
 		"jest-environment-jsdom": "^28.1.1",
+		"pinia": "^2.1.7",
 		"ts-jest": "^28.0.2",
 		"typescript": "^4.6.4",
 		"vue": "2.7.10",
 		"vue-router": "^3.6.5",
 		"vuex": "^3.6.2"
+	},
+	"peerDependencies": {
+		"pinia": "^2.0.0",
+		"vuex": "^3.0.0 || ^4.0.0"
+	},
+	"peerDependenciesMeta": {
+		"pinia": {
+			"optional": true
+		},
+		"vuex": {
+			"optional": true
+		}
 	},
 	"dependencies": {
 		"@types/gtag.js": "~0.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@farm-investimentos/front-mfe-libs-ts",
-	"version": "3.3.2",
+	"version": "3.3.3",
 	"author": "farm investimentos",
 	"description": "",
 	"license": "ISC",

--- a/src/configurations/environment/environment.ts
+++ b/src/configurations/environment/environment.ts
@@ -50,7 +50,6 @@ export default {
 	get apiSegurancaUrl(): string {
 		return FARM.APIS.seguranca;
 	},
-
 	get apiDesembolsosUrl(): string {
 		return FARM.APIS.desembolsos;
 	},
@@ -119,5 +118,9 @@ export default {
 	},
 	get apiElegibilidadeUrl() {
 		return FARM.APIS.elegibilidade;
+	},
+
+	get apiSecurityIntegrationUrl() {
+		return FARM.APIS.securityIntegrationUrl;
 	},
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from './mixins';
 
 export * from './hooks';
 export * from './composables';
+export * from './stores';

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,2 @@
+export { useUserAccessStore } from './userAccess';
+

--- a/src/stores/userAccess.spec.ts
+++ b/src/stores/userAccess.spec.ts
@@ -1,0 +1,77 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { useUserAccessStore } from './userAccess';
+
+describe('useUserAccessStore', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+	});
+
+	it('should initialize with default state', () => {
+		const store = useUserAccessStore();
+
+		expect(store.currentUserRoles).toEqual({});
+		expect(store.currentRouteRole).toBeNull();
+		expect(store.internalUser).toBeNull();
+	});
+
+	describe('getters', () => {
+		it('should return currentUserRoles', () => {
+			const store = useUserAccessStore();
+			const roles = { 'admin.users': 2 };
+			store.currentUserRoles = roles;
+
+			expect(store.getCurrentUserRoles).toEqual(roles);
+		});
+
+		it('should return currentRouteRole', () => {
+			const store = useUserAccessStore();
+			store.currentRouteRole = 'WRITE';
+
+			expect(store.getCurrentRouteRole).toBe('WRITE');
+		});
+
+		it('should return internalUser', () => {
+			const store = useUserAccessStore();
+			store.internalUser = true;
+
+			expect(store.getInternalUser).toBe(true);
+		});
+	});
+
+	describe('actions', () => {
+		it('should update currentUserRoles', () => {
+			const store = useUserAccessStore();
+			const roles = { 'admin.users': 2, 'admin.products': 1 };
+
+			store.updateCurrentUserRoles(roles);
+
+			expect(store.currentUserRoles).toEqual(roles);
+		});
+
+		it('should update currentRouteRole', () => {
+			const store = useUserAccessStore();
+
+			store.updateCurrentRouteRole('READ');
+
+			expect(store.currentRouteRole).toBe('READ');
+		});
+
+		it('should update internalUser', () => {
+			const store = useUserAccessStore();
+
+			store.updateInternalUser(true);
+
+			expect(store.internalUser).toBe(true);
+		});
+
+		it('should update internalUser to false', () => {
+			const store = useUserAccessStore();
+			store.internalUser = true;
+
+			store.updateInternalUser(false);
+
+			expect(store.internalUser).toBe(false);
+		});
+	});
+});
+

--- a/src/stores/userAccess.ts
+++ b/src/stores/userAccess.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia';
+
+interface UserAccessState {
+	currentUserRoles: Record<string, number>;
+	currentRouteRole: string | null;
+	internalUser: boolean | null;
+}
+
+export const useUserAccessStore = defineStore('userAccess', {
+	state: (): UserAccessState => ({
+		currentUserRoles: {},
+		currentRouteRole: null,
+		internalUser: null,
+	}),
+
+	getters: {
+		getCurrentUserRoles: (state) => state.currentUserRoles,
+		getCurrentRouteRole: (state) => state.currentRouteRole,
+		getInternalUser: (state) => state.internalUser,
+	},
+
+	actions: {
+		updateCurrentUserRoles(roles: Record<string, number>) {
+			this.currentUserRoles = roles;
+		},
+
+		updateCurrentRouteRole(role: string) {
+			this.currentRouteRole = role;
+		},
+
+		updateInternalUser(status: boolean) {
+			this.internalUser = status;
+		},
+	},
+});
+


### PR DESCRIPTION
This pull request introduces a new Pinia store for managing user access state, updates the package dependencies to support Pinia, and adds corresponding unit tests to ensure correct functionality. The changes improve state management flexibility and compatibility with both Pinia and Vuex.

**State management enhancements:**

* Added a new Pinia store `useUserAccessStore` in `src/stores/userAccess.ts` to manage `currentUserRoles`, `currentRouteRole`, and `internalUser`, with associated getters and actions for updating state.
* Exported the new store from `src/stores/index.ts` and exposed it in the main library entry point `src/index.ts`. [[1]](diffhunk://#diff-a962836e7056c855240fcab71b4e4f6a56e8462e298844f0b928226d230cda83R1-R2) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R10)

**Testing improvements:**

* Added unit tests for the `useUserAccessStore` in `src/stores/userAccess.spec.ts`, covering state initialization, getters, and actions.

**Dependency and compatibility updates:**

* Added `pinia` as a development and peer dependency in `package.json`, and updated `peerDependenciesMeta` to make `pinia` and `vuex` optional, ensuring compatibility with both state management libraries.
* Bumped package version to `3.4.0` in `package.json` to reflect the new features.