### PR TITLE
chore: expand pinia peer dependency to v3 and mark as required 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,10 @@
 		"vuex": "^3.6.2"
 	},
 	"peerDependencies": {
-		"pinia": "^2.0.0",
+		"pinia": "^2.0.0 || ^3.0.0",
 		"vuex": "^3.0.0 || ^4.0.0"
 	},
 	"peerDependenciesMeta": {
-		"pinia": {
-			"optional": true
-		},
 		"vuex": {
 			"optional": true
 		}


### PR DESCRIPTION
 O que mudou                                                                                                                                                 
                                                                                                                                                              
  Duas alterações no package.json:                                                                                                                            
                                                                                                                                                              
  1. Range do pinia em peerDependencies ampliado de ^2.0.0 para ^2.0.0 || ^3.0.0, seguindo o mesmo padrão já adotado para o Vuex (^3.0.0 || ^4.0.0).          
  2. Removido optional: true do pinia em peerDependenciesMeta. Na prática o pinia não é opcional: o arquivo src/stores/userAccess.ts possui um import {       
  defineStore } from 'pinia' estático que é preservado no JS compilado. Qualquer bundler de client que processe a lib tenta resolver esse import e falha com  
  Could not resolve "pinia" quando o pacote não está instalado. Marcar como opcional enganava o gerenciador de pacotes, que não avisava o consumidor sobre a
  dependência ausente.                                                                                                                                        
                                                                                                                                                            
  Por que o Vuex pode ser opcional e o Pinia não                                                                                                              
   
  Todo import de Vuex no código-fonte usa import type, que é apagado na compilação e não gera nenhum import no JS de saída. O Pinia usa import de valor       
  (defineStore), que persiste no bundle — logo, deve estar instalado obrigatoriamente. 